### PR TITLE
Simplify LineString using Douglas-Peucker algorithm

### DIFF
--- a/lib/geometry/MultiLineString.class.php
+++ b/lib/geometry/MultiLineString.class.php
@@ -16,5 +16,27 @@ class MultiLineString extends Collection
     return TRUE;
   }
 
+  // Return the first Point of the first LineString.
+  public function startPoint() {
+    return $this->components[0]->components[0];
+  }
+
+  // Return the last Point of the last LineString.
+  public function endPoint() {
+    return end(end($this->components)->components);
+  }
+
+  public function simplify($tolerance = 0.5, $preserveTopology = TRUE) {
+    $components = array();
+    foreach ($this->components as $id => $line) {
+      $startPoint = $line->startPoint();
+      $endPoint = $line->endPoint();
+
+      $startPoint->include=TRUE;
+      $endPoint->include=TRUE;
+      $components[] = $line->simplify($tolerance, $preserveTopology);
+    }
+    return new MultiLineString($components);
+  }
 }
 

--- a/lib/geometry/Point.class.php
+++ b/lib/geometry/Point.class.php
@@ -151,5 +151,19 @@ class Point extends Geometry
   public function interiorRingN($n)  { return NULL; }
   public function pointOnSurface()   { return NULL; }
   public function explode()          { return NULL; }
+
+  public function dotProduct(Point $v) {
+    return ($this->x() * $v->x() + $this->y() * $v->y());
+  }
+
+  public function magnitude() {
+    return sqrt($this->x()*$this->x() + $this->y()*$this->y());
+  }
+
+  public function unitVector() {
+    if ($this->magnitude()==0) return new Point(0,0);
+    return new Point($this->x()/$this->magnitude(),$this->y()/$this->magnitude());
+  }
+
 }
 

--- a/lib/geometry/Point.class.php
+++ b/lib/geometry/Point.class.php
@@ -157,7 +157,7 @@ class Point extends Geometry
   }
 
   public function magnitude() {
-    return sqrt($this->x()*$this->x() + $this->y()*$this->y());
+    return sqrt($this->dotProduct($this));
   }
 
   public function unitVector() {

--- a/tests/test.php
+++ b/tests/test.php
@@ -58,6 +58,7 @@ function test_geometry($geometry) {
   $geometry->geometryType();
   $geometry->SRID();
   $geometry->setSRID(4326);
+  $geometry->simplify(0.001);
 
   // Aliases
   $geometry->getCentroid();


### PR DESCRIPTION
The Douglas–Peucker algorithm is an algorithm for reducing the number of points in a curve that is approximated by a series of points.

I've implemented the algorithm, this could be the first step of a better implementation.
This could be useful for people who don't have geos extensions.

More information: http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm

Example with geoPHP:

```
x201 tests $ php test.php 
GEOS is not installed.
---- Testing 20120702.gpx
numPoints before: 2861
Running $geometry->simplify(0.01);
numPoints after: 8
Testing Done!

x201 tests $ php test.php 
GEOS is not installed.
---- Testing 20120702.gpx
numPoints before: 2861
Running $geometry->simplify(0.001);
numPoints after: 18
Testing Done!

x201 tests $ php test.php 
GEOS is not installed.
---- Testing 20120702.gpx
numPoints before: 2861
Running $geometry->simplify(0.0001);
numPoints after: 66
Testing Done!

x201 tests $ php test.php 
GEOS is not installed.
---- Testing 20120702.gpx
numPoints before: 2861
Running $geometry->simplify(0.00001);
numPoints after: 392
Testing Done!
```
