### PR TITLE
Bugfix pointInPolygon

### DIFF
--- a/lib/geometry/Polygon.class.php
+++ b/lib/geometry/Polygon.class.php
@@ -149,7 +149,7 @@ class Polygon extends Collection
     $vertices = $this->getPoints();
 
     // Check if the point sits exactly on a vertex
-    if (pointOnVertex($point, $vertices)) {
+    if ($this->pointOnVertex($point, $vertices)) {
       return $pointOnVertex ? TRUE : FALSE;
     }
   


### PR DESCRIPTION
Without "$this" it throws an "Call to undefined function pointOnVertex()" Fatal error
