### PR TITLE
Use array_unshift() instead of direct access for getting first value.

### DIFF
--- a/geoPHP.inc
+++ b/geoPHP.inc
@@ -148,7 +148,7 @@ class geoPHP
     // If it's an array of one, then just parse the one
     if (is_array($geometry)) {
       if (empty($geometry)) return FALSE;
-      if (count($geometry) == 1) return geoPHP::geometryReduce($geometry[0]);
+      if (count($geometry) == 1) return geoPHP::geometryReduce(array_unshift($geometry));
     }
 
     // If the geometry cannot even theoretically be reduced more, then pass it back


### PR DESCRIPTION
If passing an array containing a single geometry keyed by something other than 0, count() will return 1 but the recursive call to geometryReduce will receive NULL.
