### PR TITLE
Bugfix - 3d WKT is incorrectly trimmed trigguring exception in Point constructor

### DIFF
--- a/lib/adapters/WKT.class.php
+++ b/lib/adapters/WKT.class.php
@@ -45,7 +45,7 @@ class WKT extends GeoAdapter
     foreach (geoPHP::geometryList() as $geom_type) {
       $wkt_geom = strtoupper($geom_type);
       if (strtoupper(substr($wkt, 0, strlen($wkt_geom))) == $wkt_geom) {
-        $data_string = $this->getDataString($wkt, $wkt_geom);
+        $data_string = $this->getDataString($wkt);
         $method = 'parse'.$geom_type;
         
         if ($srid) {
@@ -162,7 +162,7 @@ class WKT extends GeoAdapter
     return new GeometryCollection($geometries);
   }
 
-  protected function getDataString($wkt, $type) {
+  protected function getDataString($wkt) {
     $first_paren = strpos($wkt, '(');
 
     if ($first_paren !== FALSE) {


### PR DESCRIPTION
Upon feeding the following wkt to geoPHP:

POLYGON Z((-128.5125933097632 52.591489976786676 0,-128.51202528732318 52.58862587792723 0,-128.5098799959308 52.58765715968268 0,-128.50643860753337 52.58737160240316 0,-128.50560373980377 52.5856333582354 0,-128.50668054947073 52.58332143972203 0,-128.511160140532 52.58295993724388 0,-128.5100295617859 52.57912271135264 0,-128.50769242991024 52.57904768741655 0,-128.50358964234073 52.58000532342339 0,-128.50032107849557 52.58172699664201 0,-128.50026053680517 52.5844023510514 0,-128.50303456469737 52.589381382489094 0,-128.50714344098088 52.59344278653372 0,-128.51070094205588 52.592910223116675 0,-128.5125933097632 52.591489976786676 0))

This exception was triggered:

Exception: Cannot construct Point. x and y should be numeric in Point->__construct() (line 23 of /data/workspace/projects/geoPHP/lib/geometry/Point.class.php).

Ultimately it was because the getDataString method was only trimming off the number of characters making up the basic geometry type and ignoring the Z marker.  A simple answer is to alter that method to trim off all characters before the first parenthesis, as so.
