### PR TITLE
Return an empty value if Google API returns zero results instead of throwing a fatal error.

### DIFF
--- a/lib/adapters/GoogleGeocode.class.php
+++ b/lib/adapters/GoogleGeocode.class.php
@@ -31,7 +31,7 @@ class GoogleGeocode extends GeoAdapter
    */
   public function read($address, $return_type = 'point', $bounds = FALSE, $return_multiple = FALSE) {
     if (is_array($address)) $address = join(',', $address);
-    
+
     if (gettype($bounds) == 'object') {
       $bounds = $bounds->getBBox();
     }
@@ -41,13 +41,13 @@ class GoogleGeocode extends GeoAdapter
     else {
       $bounds_string = '';
     }
-    
+
     $url = "http://maps.googleapis.com/maps/api/geocode/json";
     $url .= '?address='. urlencode($address);
     $url .= $bounds_string;
     $url .= '&sensor=false';
     $this->result = json_decode(@file_get_contents($url));
-    
+
     if ($this->result->status == 'OK') {
       if ($return_multiple == FALSE) {
         if ($return_type == 'point') {
@@ -93,12 +93,12 @@ class GoogleGeocode extends GeoAdapter
     $centroid = $geometry->getCentroid();
     $lat = $centroid->getY();
     $lon = $centroid->getX();
-    
+
     $url = "http://maps.googleapis.com/maps/api/geocode/json";
     $url .= '?latlng='.$lat.','.$lon;
     $url .= '&sensor=false';
     $this->result = json_decode(@file_get_contents($url));
-    
+
     if ($this->result->status == 'OK') {
       if ($return_type == 'string') {
         return $this->result->results[0]->formatted_address;
@@ -107,13 +107,21 @@ class GoogleGeocode extends GeoAdapter
         return $this->result->results[0]->address_components;
       }
     }
+    elseif ($this->result->status == 'ZERO_RESULTS') {
+      if ($return_type == 'string') {
+        return '';
+      }
+      if ($return_type == 'array') {
+        return $this->result->results;
+      }
+    }
     else {
       if ($this->result->status) throw new Exception('Error in Google Reverse Geocoder: '.$this->result->status);
       else throw new Exception('Unknown error in Google Reverse Geocoder');
       return FALSE;
     }
   }
-  
+
   private function getPoint($delta = 0) {
     $lat = $this->result->results[$delta]->geometry->location->lat;
     $lon = $this->result->results[$delta]->geometry->location->lng;
@@ -143,7 +151,7 @@ class GoogleGeocode extends GeoAdapter
     $lon = $this->result->results[$delta]->geometry->bounds->northeast->lng;
     return new Point($lon, $lat);
   }
-  
+
   private function getBottomLeft($delta = 0) {
     $lat = $this->result->results[$delta]->geometry->bounds->southwest->lat;
     $lon = $this->result->results[$delta]->geometry->bounds->southwest->lng;


### PR DESCRIPTION
Zero results from GoogleGeocode leads to uncaught exceptions, thus fatal errors that stop the execution of the calling script.

Although rare, it can happen that valid lat/lon input leads to zero results when doing reverse geocoding using the Google API for it, e.g.:
latitude (String, 9 characters ) 31.947750
longitude (String, 9 characters ) 35.229648

In any case, throwing a fatal error on zero results seems a bit drastic. It might be better to ... return zero results, thus an empty string if $return_type == 'string' and an empty array if $return_type == 'array'.

Thanks.