### PR TITLE
Add invertxy() methods to Point and Collection classes

### DIFF
--- a/lib/geometry/Collection.class.php
+++ b/lib/geometry/Collection.class.php
@@ -40,6 +40,24 @@ abstract class Collection extends Geometry
     return $this->components;
   }
 
+  /*
+   * Author : Adam Cherti
+   *
+   * inverts x and y coordinates
+   * Useful for old data still using lng lat
+   *
+   * @return void
+   *
+   * */
+  public function invertxy()
+  {
+	for($i=0;$i<count($this->components);$i++)
+	{
+		if( method_exists($this->components[$i], 'invertxy' ) )
+			$this->components[$i]->invertxy();
+	}
+  }
+
   public function centroid() {
     if ($this->isEmpty()) return NULL;
 

--- a/lib/geometry/Point.class.php
+++ b/lib/geometry/Point.class.php
@@ -83,6 +83,21 @@ class Point extends Geometry
     else return NULL;
   }
 
+  /**
+   * Author : Adam Cherti
+   * inverts x and y coordinates
+   * Useful with old applications still using lng lat
+   *
+   * @return void
+   * */
+  public function invertxy()
+  {
+	$x=$this->coords[0];
+	$this->coords[0]=$this->coords[1];
+	$this->coords[1]=$x;
+  }
+
+
   // A point's centroid is itself
   public function centroid() {
     return $this;


### PR DESCRIPTION
It then affects all others classes : LineString, MultiPolygon, etc. (except Geometry of course)

It's useful for some old applications or databases that still uses longitude, latitude in this order
rather than in the normalized order : latitude, longitude that is used in google maps for instance