### PR TITLE
Replace "<?" with "<?php" in tests/postgis.php

### DIFF
--- a/tests/postgis.php
+++ b/tests/postgis.php
@@ -1,4 +1,4 @@
-<?
+<?php
 // Uncomment to test
 # run_test();
 


### PR DESCRIPTION
When short tags are disabled in an IDE, the project builds with an error.
