### PR TITLE
Fix cwe367

### DIFF
--- a/lib/adapters/EWKB.class.php
+++ b/lib/adapters/EWKB.class.php
@@ -18,7 +18,7 @@ class EWKB extends WKB
     }
     
     // Open the wkb up in memory so we can examine the SRID
-    $mem = fopen('php://memory', 'r+');
+    $mem = fopen('php://memory', 'x+'); //Fixed CWE-367
     fwrite($mem, $wkb);
     fseek($mem, 0);
     $base_info = unpack("corder/ctype/cz/cm/cs", fread($mem, 5));

--- a/lib/adapters/WKB.class.php
+++ b/lib/adapters/WKB.class.php
@@ -37,7 +37,7 @@ class WKB extends GeoAdapter
       throw new Exception('Cannot read empty WKB geometry. Found ' . gettype($wkb));
     }
 
-    $mem = fopen('php://memory', 'r+');
+    $mem = fopen('php://memory', 'x+'); //Fixed CWE-367
     fwrite($mem, $wkb);
     fseek($mem, 0);
 


### PR DESCRIPTION
The fopen() call used here uses the r+ mode which opens the file for reading and writing. This however may cause issues if several concurrent requests are served using the same file and lead to the corruption of the files and in this case memory. Consider using the 'x+' mode for exclusive file access to read and write Well Known Binaries and Extended Well Known Binaries. 
