### PR TITLE
Ensure associative arrays are properly normalised

### DIFF
--- a/lib/adapters/WKB.class.php
+++ b/lib/adapters/WKB.class.php
@@ -108,8 +108,9 @@ class WKB extends GeoAdapter
     $components = array();
     $i = 1;
     $num_coords = count($line_coords);
+    $line_coord_values = array_values($line_coords);
     while ($i <= $num_coords) {
-      $components[] = new Point($line_coords[$i],$line_coords[$i+1]);
+      $components[] = new Point($line_coord_values[$i],$line_coord_values[$i+1]);
       $i += 2;
     }
     return new LineString($components);

--- a/lib/adapters/WKB.class.php
+++ b/lib/adapters/WKB.class.php
@@ -103,13 +103,21 @@ class WKB extends GeoAdapter
 
     // Read the nubmer of points x2 (each point is two coords) into decimal-floats
     $line_coords = unpack('d*', fread($mem,$line_length[1]*$this->dimension*8));
+    ksort($line_coords);
 
     // We have our coords, build up the linestring
     $components = array();
-    $i = 1;
+    $i = 0;
     $num_coords = count($line_coords);
     $line_coord_values = array_values($line_coords);
     while ($i <= $num_coords) {
+      // Drop any malformed points.
+      if (!array_key_exists($i, $line_coord_values)) {
+        break;
+      }
+      if (!array_key_exists($i+1, $line_coord_values)) {
+        break;
+      }
       $components[] = new Point($line_coord_values[$i],$line_coord_values[$i+1]);
       $i += 2;
     }

--- a/lib/adapters/WKB.class.php
+++ b/lib/adapters/WKB.class.php
@@ -107,20 +107,15 @@ class WKB extends GeoAdapter
 
     // We have our coords, build up the linestring
     $components = array();
-    $i = 0;
-    $num_coords = count($line_coords);
-    $line_coord_values = array_values($line_coords);
-    while ($i <= $num_coords) {
-      // Drop any malformed points.
-      if (!array_key_exists($i, $line_coord_values)) {
-        break;
-      }
-      if (!array_key_exists($i+1, $line_coord_values)) {
-        break;
-      }
-      $components[] = new Point($line_coord_values[$i],$line_coord_values[$i+1]);
-      $i += 2;
-    }
+
+    // Chunk array into 2-tuples, discarding any malformed elements.
+    $line_coords_filtered = array_filter(array_chunk($line_coords, 2), function($i) {
+      return count($i) == 2;
+    });
+    $components = array_map(function($i) {
+      return new Point($i[0], $i[1]);
+    }, $line_coords_filtered);
+
     return new LineString($components);
   }
 


### PR DESCRIPTION
I'm currently working with geoPHP within Drupal to generate polygons for geographical regions, but for some reason some of the arrays that are coming into `WKB.class.php` are associative, with their index starting from `1`. In these cases, when `$components[] = new Point($line_coords[$i],$line_coords[$i+1]);` is called, an exception is thrown because `$line_coords` has no key `$i + 1`.

I intend to investigate why this function is getting malformed keys, and try and correct it, but decided to put together some sort of interim remedy in case anyone else had the same problem. This PR normalises the input array so that it's no longer associative, ensuring that the keys start from `0` and are properly consecutive. It also ensures that any malformed points are dropped. (Is your policy to drop malformed points, or to try and display them by any means necessary?)

<strike>Am also wondering if maybe we could use `array_chunk` to chunk the array into 2-tuples, and then clean up any malformed ones at the end.</strike> Actually, I've gone ahead and done that. Requires PHP 5.3+, but the functionality in question is much more apparent now.
