### PR TITLE
handle navionics.kml files with tab-separated coordinates

### DIFF
--- a/lib/adapters/KML.class.php
+++ b/lib/adapters/KML.class.php
@@ -176,7 +176,7 @@ class KML extends GeoAdapter
     $coord_elements = $this->childElements($xml, 'coordinates');
     $coordinates = array();
     if (count($coord_elements)) {
-      $coord_sets = explode(' ', preg_replace('/[\r\n]+/', ' ', $coord_elements[0]->nodeValue));
+      $coord_sets = explode(' ', preg_replace('/[\r\n\t]+/', ' ', $coord_elements[0]->nodeValue));
       foreach ($coord_sets as $set_string) {
         $set_string = trim($set_string);
         if ($set_string) {


### PR DESCRIPTION
I had issues reading the KML files produced with the Navionics Sailing Chart app, as it separates coordinated with a TAB instead of newline or CR.

This pull requests fixes this, by also splitting at TAB character. 

Link to app:
http://www.navionics.com/en/mobile-pc-app-1