### PR TITLE
Add attribute support for KML

### DIFF
--- a/geoPHP.inc
+++ b/geoPHP.inc
@@ -166,6 +166,7 @@ class geoPHP
       if (in_array(get_class($geometry),$passbacks)) {
         $components = $geometry->getComponents();
         if (count($components) == 1) {
+          $components[0]->mergeAttributes($geometry->attributes);
           return $components[0];
         }
         else {
@@ -183,11 +184,12 @@ class geoPHP
     $geom_types = array();
 
     $collections = array('MultiPoint','MultiLineString','MultiPolygon','GeometryCollection');
-
     foreach ($geometry as $item) {
       if ($item) {
         if (in_array(get_class($item), $collections)) {
           foreach ($item->getComponents() as $component) {
+            if ($item->numGeometries() == 1)
+		$component->mergeAttributes($item);
             $geometries[] = $component;
             $geom_types[] = $component->geometryType();
           }

--- a/lib/adapters/KML.class.php
+++ b/lib/adapters/KML.class.php
@@ -79,13 +79,22 @@ class KML extends GeoAdapter
     $placemark_elements = $this->xmlobj->getElementsByTagName('placemark');
     if ($placemark_elements->length) {
       foreach ($placemark_elements as $placemark) {
+        $geometry = false;
+        $attributes = array();
         foreach ($placemark->childNodes as $child) {
           // Node names are all the same, except for MultiGeometry, which maps to GeometryCollection
           $node_name = $child->nodeName == 'multigeometry' ? 'geometrycollection' : $child->nodeName;
           if (array_key_exists($node_name, $geom_types)) {
             $function = 'parse'.$geom_types[$node_name];
-            $geometries[] = $this->$function($child);
+            $geometry = $this->$function($child);
+          } elseif ($child->nodeType == 1 && $child->childNodes->length == 1) {
+            $attributes[$child->nodeName] = $child->nodeValue;
           }
+        }
+        if ($geometry !== false)
+        {
+          $geometry->attributes = $attributes;
+          $geometries[] = $geometry;
         }
       }
     }

--- a/lib/geometry/Geometry.class.php
+++ b/lib/geometry/Geometry.class.php
@@ -8,6 +8,8 @@ abstract class Geometry
   private   $geos = NULL;
   protected $srid = NULL;
   protected $geom_type;
+  
+  public $attributes = array();
 
   // Abtract: Standard
   // -----------------
@@ -344,4 +346,8 @@ abstract class Geometry
     return NULL;
   }
 
+  public function mergeAttributes($mergeWith)
+  {
+    $this->attributes = array_merge($mergeWith->attributes, $this->attributes);
+  }
 }


### PR DESCRIPTION
This only adds support for metadata from KML files, no other formats.
It does not support writing the metadata when using write().

It does add the groundwork for more extensive metadata handling in geoPHP however and may be useful to others as-is.

Some work was done to geometryReduce to preserve metadata from collections that are optimised away.