### PR TITLE
make WKT.class.php more strict

### DIFF
--- a/lib/adapters/WKT.class.php
+++ b/lib/adapters/WKT.class.php
@@ -219,7 +219,7 @@ class WKT extends GeoAdapter
       return strtoupper($geometry->geometryType()).' EMPTY';
     }
     else if ($data = $this->extractData($geometry)) {
-      return strtoupper($geometry->geometryType()).' ('.$data.')';
+      return strtoupper($geometry->geometryType()).'('.$data.')';
     }
   }
 


### PR DESCRIPTION
Hi,

today i had to debug a surprising problem: WKT linestrings produced by geoPHP where not recognised by the remote server. Further investigation revealed, that their wkt parsing library does not expect a space before left parentheses of LINESTRING.

Crosschecking with http://www.opengeospatial.org/standards/sfa reveals: within the OpenGIS standard examples are written with space before left parenthesis. However, the BNF does not allow for spaces (see Section 7.2.2 the productions `linestring tagged text` and `linestring text` do not make any mention of `<space>`). I was also unable to find any general remarks regarding whitespaces (for example: there is the normative text outside BNF that left and right delimiters need to be balanced).

All this, of course, is not a problem with geoPHP but with the remote server.
However, I was thinking about: if the BNF in the standard mandates no space before left parenthesis (that is: `LINESTRING(` opposed to `LINESTRING (`), then, in accordance with Jon Postel's "strict in what you send"-principal, geoPHP should continue to parse many input strings but only produce output strings without space.

Please let me know what you think,

regards,
Max