### PR TITLE
Fix conversion to KML when LineString should be a LinearRing

### DIFF
--- a/lib/adapters/KML.class.php
+++ b/lib/adapters/KML.class.php
@@ -224,6 +224,16 @@ class KML extends GeoAdapter
   private function linestringToKML($geom, $type = FALSE) {
     if (!$type) {
       $type = $geom->getGeomType();
+
+      if ($type === 'LineString') {
+        $components = $geom->getComponents();
+        $firstPoint = array_shift($components);
+        $lastPoint = array_pop($components);
+
+        if ($firstPoint->equals($lastPoint)) {
+          $type = 'LinearRing';
+        }
+      }
     }
 
     $str = '<'.$this->nss . $type .'>';


### PR DESCRIPTION
Quick fix for the conversion to KML when the LineString should be considered as a LinearRing.